### PR TITLE
Fix night build

### DIFF
--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -10,7 +10,14 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
 #![no_std]
-#![cfg_attr(all(curve25519_dalek_backend = "simd", nightly), feature(stdsimd))]
+#![cfg_attr(
+    all(
+        curve25519_dalek_backend = "simd",
+        nightly,
+        any(target_arch = "x86", target_arch = "x86_64")
+    ),
+    feature(stdarch_x86_avx512)
+)]
 #![cfg_attr(
     all(curve25519_dalek_backend = "simd", nightly),
     feature(avx512_target_feature)


### PR DESCRIPTION

Patch Reference https://github.com/dalek-cryptography/curve25519-dalek/pull/619


Started getting this error in our GitHub CI , might be related to [stdarc submodule update](https://github.com/rust-lang/rust/pull/117372,
)

https://github.com/webb-tools/gadget/actions/runs/7918714022/job/21618159674

```
error[E0658]: use of unstable library feature 'stdsimd'
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-ml-4.1.2/src/backend/vector/ifma/field.rs:26:5
   |
26 |     _mm256_madd52lo_epu64(z.into(), x.into(), y.into()).into()
   |     ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
   = help: add `#![feature(stdsimd)]` to the crate attributes to enable

error[E0658]: use of unstable library feature 'stdsimd'
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-ml-4.1.2/src/backend/vector/ifma/field.rs:25:9
   |
25 |     use core::arch::x86_64::_mm256_madd52lo_epu64;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
   = help: add `#![feature(stdsimd)]` to the crate attributes to enable

error[E0658]: use of unstable library feature 'stdsimd'
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-ml-4.1.2/src/backend/vector/ifma/field.rs:34:5
   |
34 |     _mm256_madd52hi_epu64(z.into(), x.into(), y.into()).into()
   |     ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
   = help: add `#![feature(stdsimd)]` to the crate attributes to enable

error[E0658]: use of unstable library feature 'stdsimd'
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-ml-4.1.2/src/backend/vector/ifma/field.rs:33:9
   |
33 |     use core::arch::x86_64::_mm256_madd52hi_epu64;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
   = help: add `#![feature(stdsimd)]` to the crate attributes to enable

error[E0635]: unknown feature `stdarch_x86_avx512`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-ml-4.1.2/src/lib.rs:19:13
   |
19 |     feature(stdarch_x86_avx512)
   |             ^^^^^^^^^^^^^^^^^^

    Checking ed448-goldilocks-plus v0.11.1
Some errors have detailed explanations: E0635, E0658.
For more information about an error, try `rustc --explain E0635`.
error: could not compile `curve25519-dalek-ml` (lib) due to 5 previous errors
```

